### PR TITLE
feat: add resusable tabs, tab components

### DIFF
--- a/src/components/common/Tabs.jsx
+++ b/src/components/common/Tabs.jsx
@@ -1,0 +1,40 @@
+import { useState } from "react"
+
+const Tabs = ({ defaultTab, children }) => {
+    const [activeTab, setActiveTab] = useState(defaultTab);
+
+    const tabs = children.map(child => ({
+        id: child.props.id,
+        label: child.props.label,
+        content: child.props.children
+    }))
+
+    return (
+        <>
+            <div className="border-b border-gray-200">
+                <nav className="-mb-px flex space-x-8">
+                    {tabs.map(tab => (
+                        <button
+                            key={tab.id}
+                            onClick={() => setActiveTab(tab.id)}
+                            className={`whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ${activeTab === tab.id
+                                ? 'border-blue-500 text-blue-600'
+                                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                        >
+                            {tab.label}
+                        </button>
+                    ))}
+                </nav>
+            </div>
+            <div className="py-4">
+                {tabs.find(tab => tab.id === activeTab)?.content}
+            </div>
+        </>
+    )
+}
+
+const Tab = ({ id, label, children }) => {
+    return <div id={id} label={label} >{children}</div>
+}
+
+export { Tabs, Tab }


### PR DESCRIPTION
This pull request introduces a new `Tabs` component and its associated `Tab` subcomponent to the `src/components/common/Tabs.jsx` file. These components are designed to create a tabbed navigation interface with dynamic content switching.

Key changes include:

* **New `Tabs` Component**:
  * Introduced a `Tabs` component that manages the state of the active tab using the `useState` hook.
  * The component maps over its children to create tab buttons and dynamically displays the content of the active tab.

* **New `Tab` Subcomponent**:
  * Added a `Tab` subcomponent to encapsulate the content and properties of individual tabs.

These changes enhance the user interface by providing a reusable tabbed navigation component.