### PR TITLE
feat: add overview page with overview stat card component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,13 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router"
 import DashboardLayout from "./components/layout/DashboardLayout"
+import OverviewPage from "./pages/dashboard/OverviewPage"
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route element={<DashboardLayout />}>
-          <Route index element={<h1>Overview</h1>} />
+          <Route index element={<OverviewPage />} />
           <Route path="/users" element={<h1>Users</h1>} />
           <Route path="/products" element={<h1>Products</h1>} />
           <Route path="/settings" element={<h1>Settings</h1>} />

--- a/src/components/dashboard/OverviewStatCard.jsx
+++ b/src/components/dashboard/OverviewStatCard.jsx
@@ -1,0 +1,21 @@
+const OverviewStatCard = ({
+    title,
+    stat,
+    change,
+    changeType = "positive"
+}) => {
+    const changeColorClasses = {
+        positive: "text-green-500",
+        negative: "text-red-500",
+        neutral: "text-gray-500"
+    }
+    return (
+        <div className="bg-white rounded-lg p-6 shadow">
+            <h3 className="text-gray-500 text-sm font-medium">{title}</h3>
+            <p className="text-3xl font-bold text-gray-800 mt-2">{stat}</p>
+            <p className={`${changeColorClasses[changeType]} text-sm mt-1`}>{change}</p>
+        </div>
+    )
+}
+
+export default OverviewStatCard

--- a/src/pages/dashboard/OverviewPage.jsx
+++ b/src/pages/dashboard/OverviewPage.jsx
@@ -1,0 +1,62 @@
+import { Tabs, Tab } from '../../components/common/Tabs'
+import Button from '../../components/common/Button'
+import OverviewStatCard from '../../components/dashboard/OverviewStatCard'
+
+const OverviewPage = () => {
+    return (
+        <div>
+            <h2 className='text-2xl font-bold text-gray-800 mb-6'>Dashboard Overview</h2>
+
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8'>
+                <OverviewStatCard
+                    title="Total Users"
+                    stat="1,234"
+                    change="+12% from last month"
+                    changeType="positive"
+                />
+                <OverviewStatCard
+                    title="Revenue"
+                    stat="$34,000"
+                    change="+8% from last month"
+                    changeType="positive"
+                />
+                <OverviewStatCard
+                    title="Active Products"
+                    stat="256"
+                    change="-3% from last month"
+                    changeType="negative"
+                />
+                <OverviewStatCard
+                    title="Conversion Rate"
+                    stat="3.2%"
+                    change="+0.5% from last month"
+                    changeType="positive"
+                />
+            </div>
+
+            <Tabs defaultTab="recentActivity">
+                <Tab id="recentActivity" label="Recent Activity">
+                    <div className="bg-white p-6 rounded-lg shadow">
+                        <p>Recent Activities will be displayed here.</p>
+                    </div>
+                </Tab>
+                <Tab id="statistics" label="Statistics">
+                    <div className="bg-white p-6 rounded-lg shadow">
+                        <p>Statistics will be displayed here.</p>
+                    </div>
+                </Tab>
+                <Tab id="quickActions" label="Quick Actions">
+                    <div className="bg-white p-6 rounded-lg shadow">
+                        <div className="flex space-x-4">
+                            <Button variant="primary">Generate Report</Button>
+                            <Button variant="secondary">Export Data</Button>
+                            <Button variant="danger">Reset Dashboard</Button>
+                        </div>
+                    </div>
+                </Tab>
+            </Tabs>
+        </div>
+    )
+}
+
+export default OverviewPage


### PR DESCRIPTION
This pull request introduces a new `OverviewPage` component to the dashboard and includes the creation of a reusable `OverviewStatCard` component. These changes enhance the dashboard's functionality and user interface.

New components and their integration:

* [`src/pages/dashboard/OverviewPage.jsx`](diffhunk://#diff-6bb780327e632d3220ef0cf57e161761832348dc8cc5f2e3b5ad82be6de2e79fR1-R62): Added the `OverviewPage` component, which includes a header, a grid of `OverviewStatCard` components displaying various statistics, and a tabbed section for recent activity, statistics, and quick actions.
* [`src/components/dashboard/OverviewStatCard.jsx`](diffhunk://#diff-6c9a0cca45e2739dbad2ff110fe3f7626574779f628b8bf3adf87a7f510d3026R1-R21): Created the `OverviewStatCard` component to display individual statistics with a title, value, and change indicator.

Routing updates:

* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R3-R10): Modified the routing to render the new `OverviewPage` component at the dashboard's root path instead of a placeholder heading.