### PR TITLE
feat: add users page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router"
 import DashboardLayout from "./components/layout/DashboardLayout"
 import OverviewPage from "./pages/dashboard/OverviewPage"
+import UsersPage from "./pages/dashboard/UsersPage"
 
 function App() {
   return (
@@ -8,7 +9,7 @@ function App() {
       <Routes>
         <Route element={<DashboardLayout />}>
           <Route index element={<OverviewPage />} />
-          <Route path="/users" element={<h1>Users</h1>} />
+          <Route path="/users" element={<UsersPage />} />
           <Route path="/products" element={<h1>Products</h1>} />
           <Route path="/settings" element={<h1>Settings</h1>} />
         </Route>

--- a/src/pages/dashboard/UsersPage.jsx
+++ b/src/pages/dashboard/UsersPage.jsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import DataTable from "../../components/common/DataTable";
+import Modal from "../../components/common/Modal"
+import Button from "../../components/common/Button";
+
+
+const UsersPage = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedUser, setSelectedUser] = useState(null);
+
+    const users = [
+        { id: 1, name: 'John Doe', email: 'john@example.com', role: 'Admin', status: 'Active' },
+        { id: 2, name: 'Jane Smith', email: 'jane@example.com', role: 'User', status: 'Active' },
+        { id: 3, name: 'Bob Johnson', email: 'bob@example.com', role: 'User', status: 'Inactive' },
+    ];
+
+    const columns = [
+        { key: 'name', title: 'Name' },
+        { key: 'email', title: 'Email' },
+        { key: 'role', title: 'Role' },
+        {
+            key: 'status',
+            title: 'Status',
+            render: (value) => (
+                <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${value === 'Active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                    }`}>
+                    {value}
+                </span>
+            )
+        },
+    ];
+
+    const handleRowClick = (user) => {
+        setSelectedUser(user);
+        setIsModalOpen(true);
+    }
+
+    return (
+        <div>
+            <div className="flex justify-between items-center mb-6">
+                <h2 className="text-2xl font-bold text-gray-800">Users</h2>
+                <Button variant="primary" onClick={() => setIsModalOpen(true)}>
+                    Add User
+                </Button>
+            </div>
+
+            <DataTable
+                columns={columns}
+                data={users}
+                onRowClick={handleRowClick}
+            />
+
+            <Modal
+                isOpen={isModalOpen}
+                onClose={() => {
+                    setIsModalOpen(false);
+                    setSelectedUser(null);
+                }}
+                title={selectedUser ? `User Details` : 'Add New User'}
+            >
+                {
+                    selectedUser ? (
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700">Name</label>
+                                <p className="mt-1 text-sm text-gray-900">{selectedUser.name}</p>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700">Email</label>
+                                <p className="mt-1 text-sm text-gray-900">{selectedUser.email}</p>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700">Role</label>
+                                <p className="mt-1 text-sm text-gray-900">{selectedUser.role}</p>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700">Status</label>
+                                <p className="mt-1 text-sm text-gray-900">{selectedUser.status}</p>
+                            </div>
+                        </div>
+                    ) : (
+                        <form className="space-y-4">
+                            <div>
+                                <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                                    Name
+                                </label>
+                                <input
+                                    type="text"
+                                    id="name"
+                                    className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                                    Email
+                                </label>
+                                <input
+                                    type="text"
+                                    id="email"
+                                    className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="role" className="block text-sm font-medium text-gray-700">
+                                    Role
+                                </label>
+                                <select
+                                    id="role"
+                                    className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                >
+                                    <option value="admin">Admin</option>
+                                    <option value="user">User</option>
+                                </select>
+                            </div>
+                        </form>
+                    )
+                }
+            </Modal>
+        </div>
+    )
+}
+
+export default UsersPage


### PR DESCRIPTION
This pull request introduces a new `UsersPage` component to the dashboard and updates the routing to use this new component. The changes include the addition of a data table for displaying user information and a modal for viewing and adding users.

### Routing updates:
* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R4-R12): Updated the route for `/users` to use the new `UsersPage` component instead of a placeholder `<h1>` element.

### New `UsersPage` component:
* [`src/pages/dashboard/UsersPage.jsx`](diffhunk://#diff-46aa29196b6a2bcf028eb143e160abf4a3788280121c80b6b9515e191d9b2903R1-R123): Created a new `UsersPage` component that includes a data table to display user information and a modal for viewing and adding users. The component uses `useState` to manage modal state and selected user details.